### PR TITLE
Added IOCs for React2Shell (CVE-2025-55182)

### DIFF
--- a/2025_12_10-react2shell-iocs.csv
+++ b/2025_12_10-react2shell-iocs.csv
@@ -1,0 +1,112 @@
+indicator_type,data,additional_data,description
+source,https://www.bitdefender.com/en-us/blog/businessinsights/advisory-react2shell-critical-unauthenticated-rce-in-react-cve-2025-55182,https://intellizone.bitdefender.com/en/threat-search/threats/BDs7zjeguz,Technical Advisory: React2Shell Critical Unauthenticated RCE in React (CVE-2025-55182)
+source,https://www.bitdefender.com/en-us/blog/labs/cve-2025-55182-exploitation-hits-the-smart-home,https://intellizone.bitdefender.com/en/threat-search/threats/BDs7zjeguz,CVE-2025-55182 Exploitation Hits the Smart Home
+ip,143[.]20[.]64[.]39,Reverse Shell Destination (Port 443)
+ip,72[.]62[.]67[.]33,MeshAgent Download Host
+ip,38[.]60[.]206[.]181,Cobalt Strike C2
+domain,repositorylinux[.]xyz,Malicious PowerShell Script Host
+domain,evolution-home[.]ru,Mining Host
+domain,superminecraft[.]net[.]br,Linux Script Host (Port 3000)
+domain,pool[.]supportxmr[.]com,Mining Pool (Port 8080)
+domain,thorconn[.]com,Compromised Staging Site (Cobalt Strike)
+domain,gfxnick[.]emerald[.]usbx[.]me,Malicious Domain
+url,hxxps://f003[.]backblazeb2[.]com/file/mova12/98201-1-8/bot,Payload Delivery Server
+url,https://header-redeem-polymer-above.trycloudflare[.]com/w.ps1,Temporary Payload Delivery Server
+file,db5f8f6941c51f6583343df0f975417b,meshagent,MeshCentral Agent
+file,72bfc699d40b9292cb47e7f43aeb2166,lol.exe, Adaptix Gopher
+ip,194[.]26[.]192[.]199,C2 Server for Adaptix Gopher
+file,72a37a2fa588e013eafd695b8b5b0e61,,XMRig Miner
+url,http://128[.]199[.]194[.]97:9001/alive[.]sh,,Payload Delivery Server for XMRIG
+url,http://128[.]199[.]194[.]97:9001/setup2[.]sh,,Payload Delivery Server for XMRIG
+url,http://128[.]199[.]194[.]97:9001/runnv[.]tar[.]gz,,Payload Delivery Server for XMRIG
+url,http://185[.]164[.]163[.]34:8181/[.]dcplm,,Payload Delivery Server for XMRIG
+url,http://167[.]86[.]107[.]35:9999/muie[.]sh,,Payload Delivery Server for XMRIG
+ip,176[.]117[.]107[.]154,IPs Found in Malicious Commands
+ip,23[.]228[.]188[.]126,IPs Found in Malicious Commands
+ip,23[.]132[.]164[.]54,IPs Found in Malicious Commands
+ip,31[.]56[.]27[.]76,IPs Found in Malicious Commands
+ip,89[.]144[.]31[.]18,IPs Found in Malicious Commands
+ip,41[.]231[.]37[.]153,IPs Found in Malicious Commands
+ip,172[.]237[.]55[.]180,IPs Found in Malicious Commands
+ip,115[.]42[.]60[.]97,IPs Found in Malicious Commands
+ip,172[.]245[.]79[.]16,IPs Found in Malicious Commands
+ip,185[.]196[.]10[.]247,IPs Found in Malicious Commands
+ip,149[.]248[.]44[.]88,IPs Found in Malicious Commands
+ip,77[.]110[.]110[.]55,IPs Found in Malicious Commands
+ip,13[.]235[.]158[.]164,IPs Found in Malicious Commands
+ip,158[.]94[.]209[.]210,IPs Found in Malicious Commands
+ip,2[.]57[.]122[.]173,IPs Found in Malicious Commands
+ip,195[.]178[.]110[.]131,IPs Found in Malicious Commands
+ip,185[.]177[.]72[.]11,IPs Found in Malicious Commands
+ip,84[.]247[.]176[.]139,IPs Found in Malicious Commands
+ip,45[.]148[.]10[.]117,IPs Found in Malicious Commands
+ip,104[.]200[.]73[.]215,IPs Found in Malicious Commands
+file,622f904bb82c8118da2966a957526a2b,bot,Botnet loader
+file,a51a5c1e7d2bc3f7b2e3489f92a55d46,h437,Malicious Payload
+file,aaca45131c5a5a95d384431e415474f7,linux_mips,Malicious Payload
+file,ca7f4b8e296fc4ef46ecb07218434e1b,linux_mips64,Malicious Payload
+file,c50db4734195579e83834b2a84758cea,linux_mipsel,Malicious Payload
+file,e13a61420568eb596224ff8e48ea415a,mips,Malicious Payload
+file,025f5e04e54497242749ec480310fd7e,nginx3,Malicious Payload
+file,3ba4d5e0cf0557f03ee5a97a2de56511,x86,Malicious Payload
+file,bf9d7224e709b4ac90a498418af20d3a,config1,Malicious Payload
+file,4c7c33f3c94eb1f64d90a549c379e0ce,bolts,Malicious Payload
+file,825047695fc16c6edd7ea5cf29ae0b61,colonna.arm,Malicious Payload
+file,ac3659f65e136d1488b500454319a97b,colonna.arm6,Malicious Payload
+file,5253d53d3cccba87958ae42d2aee7242,colonna.arm7,Malicious Payload
+file,e96c2ef6014bbd7380d3fb4931d16162,colonna.m68k,Malicious Payload
+file,0fa1e8cfd9226ece92ca1b37d2531fea,colonna.mips,Malicious Payload
+file,4828deaae0dedd28081941cbecf74ca1,colonna.mpsl,Malicious Payload
+file,a7b8c324d9516811637fc39348f91c5f,colonna.ppc,Malicious Payload
+file,41963febe3f5930f3602f94df1387341,colonna.spc,Malicious Payload
+file,0731db9d75ec47b9357f6463a2bdbf97,colonna.x86,Malicious Payload
+file,6a5ef3e727f3d392408fbc18f4ef3b7a,colonna.x86_64,Malicious Payload
+file,bb19326971f89e65a217239b45adc624,linux_386,Malicious Payload
+file,4f594f18e469ed89ca526fdff6b75308,linux_aarch64,Malicious Payload
+file,40c33a4e58bb36c3afef607d0b44f8e8,linux_amd64,Malicious Payload
+file,a7ebfb7fa2bbf85d2c8e8431d0958302,linux_mips64el,Malicious Payload
+file,846abed0f72fd760829255e0ad288f8c,node,Malicious Payload
+ip,95[.]214[.]52[.]170,Suspicious scanner activity
+ip,149[.]50[.]96[.]133,Suspicious scanner activity
+ip,193[.]34[.]213[.]150,Suspicious scanner activity
+ip,95[.]214[.]52[.]169,Suspicious scanner activity
+ip,192[.]159[.]99[.]95,Suspicious scanner activity
+ip,79[.]124[.]40[.]174,Suspicious scanner activity
+ip,78[.]108[.]180[.]87,Suspicious scanner activity
+ip,202[.]120[.]234[.]124,Suspicious scanner activity
+ip,45[.]61[.]157[.]12,Suspicious scanner activity
+ip,194[.]165[.]16[.]11,Suspicious scanner activity
+ip,37[.]19[.]207[.]89,Suspicious scanner activity
+ip,103[.]98[.]176[.]214,Suspicious scanner activity
+ip,87[.]120[.]191[.]92,Suspicious scanner activity
+ip,118[.]179[.]152[.]153,Suspicious scanner activity
+ip,168[.]187[.]178[.]156,Suspicious scanner activity
+ip,98[.]109[.]53[.]19,Suspicious scanner activity
+ip,34[.]133[.]236[.]48,Suspicious scanner activity
+ip,27[.]74[.]251[.]56,Suspicious scanner activity
+ip,189[.]124[.]16[.]247,Suspicious scanner activity
+ip,198[.]38[.]91[.]111,Suspicious scanner activity
+ip,12[.]11[.]71[.]194,Suspicious scanner activity
+ip,160[.]250[.]70[.]17,Suspicious scanner activity
+ip,202[.]120[.]234[.]163,Suspicious scanner activity
+ip,221[.]148[.]108[.]52,Suspicious scanner activity
+ip,12[.]14[.]37[.]157,Suspicious scanner activity
+ip,174[.]138[.]25[.]84,Suspicious scanner activity
+ip,176[.]65[.]148[.]93,Suspicious scanner activity
+ip,103[.]73[.]39[.]117,Suspicious scanner activity
+ip,212[.]240[.]189[.]254,Suspicious scanner activity
+ip,162[.]252[.]198[.]150,Suspicious scanner activity
+ip,189[.]99[.]185[.]156,Suspicious scanner activity
+ip,209[.]38[.]37[.]143,Suspicious scanner activity
+ip,115[.]42[.]60[.]214,Suspicious scanner activity
+ip,194[.]27[.]101[.]106,Suspicious scanner activity
+ip,221[.]216[.]138[.]38,Suspicious scanner activity
+ip,198[.]38[.]91[.]110,Suspicious scanner activity
+ip,103[.]196[.]152[.]73,Suspicious scanner activity
+ip,13[.]202[.]71[.]165,Suspicious scanner activity
+ip,37[.]221[.]215[.]69,Suspicious scanner activity
+ip,41[.]216[.]191[.]128,Suspicious scanner activity
+ip,177[.]86[.]120[.]77,Suspicious scanner activity
+ip,161[.]35[.]17[.]13,Suspicious scanner activity
+ip,103[.]177[.]225[.]10,Suspicious scanner activity
+ip,94[.]183[.]232[.]40,Suspicious scanner activity


### PR DESCRIPTION
https://www.bitdefender.com/en-us/blog/businessinsights/advisory-react2shell-critical-unauthenticated-rce-in-react-cve-2025-55182